### PR TITLE
Improve NG vs PTC test system

### DIFF
--- a/tests/tests/test-ptc-maps/test-misalign-maps.mad
+++ b/tests/tests/test-ptc-maps/test-misalign-maps.mad
@@ -68,7 +68,7 @@ function TestMis:testSBENDmis() !-> ptc does rotation x, y, s not y, -x, s as ng
   }
   require("test-tool").args_to_cfg(cfg) -- Need to check if we are doing a cmap test
   if cfg.cmap then
-    cfg = cfg {
+    cfg = cfg "sbend_mis_c" {
       dtheta    = \s->    s.cur_cfg.dodtheta and {0, 1e-3,-0.1} or {0},
       dphi      = \s->not s.cur_cfg.dodtheta and {0,-1e-3, 0.1} or {0},
       dodtheta  = {false, true},
@@ -116,7 +116,7 @@ function TestMis:testRBENDmis() !-> ptc does rotation x, y, s not y, -x, s as ng
   
   require("test-tool").args_to_cfg(cfg) -- Need to check if we are doing a cmap test
   if cfg.cmap then
-    cfg = cfg {
+    cfg = cfg "rbend_mis_c" {
       dtheta    = \s -> ((not s.cur_cfg.true_rbend and     s.cur_cfg.dodtheta) and {0, 1e-3,-0.1} or {0}),
       dphi      = \s -> ((not s.cur_cfg.true_rbend and not s.cur_cfg.dodtheta) and {0,-1e-3, 0.1} or {0}),
       dpsi      = \s -> ((not s.cur_cfg.true_rbend                           ) and {0, 1e-3,-0.1} or {0}), 

--- a/tests/tests/test-ptc-maps/test-misalign-maps.mad
+++ b/tests/tests/test-ptc-maps/test-misalign-maps.mad
@@ -66,8 +66,20 @@ function TestMis:testSBENDmis() !-> ptc does rotation x, y, s not y, -x, s as ng
       filename = "sbend-mis-rot-ngvng.png",
     },
   }
+  require("test-tool").args_to_cfg(cfg) -- Need to check if we are doing a cmap test
+  if cfg.cmap then
+    cfg = cfg {
+      dtheta    = \s->    s.cur_cfg.dodtheta and {0, 1e-3,-0.1} or {0},
+      dphi      = \s->not s.cur_cfg.dodtheta and {0,-1e-3, 0.1} or {0},
+      dodtheta  = {false, true},
 
-  run_test(cfg)
+      alist = tblcat({"dodtheta"}, cfg.alist)
+    }
+    run_test(cfg)
+    MAD.warn("TestMis.testSBENDmis: Test limited to not combine dtheta and dphi, as PTC does the rotations in a different order.")
+  else
+    run_test(cfg)
+  end
 end
 
 function TestMis:testRBENDmis() !-> ptc does rotation x, y, s not y, -x, s as ng
@@ -94,7 +106,7 @@ function TestMis:testRBENDmis() !-> ptc does rotation x, y, s not y, -x, s as ng
     dpsi      = {0, 1e-3,-0.1},
     true_rbend= {true, false},
 
-    alist = tblcat(ref_cfg.alist, {"angle_div", "translate", "dtheta", "dphi", "dpsi", "true_rbend"}),
+    alist = tblcat(ref_cfg.alist, {"true_rbend", "angle_div", "translate", "dtheta", "dphi", "dpsi"}),
 
     plot_info = {
       title    = "RBend Misaligned d(theta/phi/psi) NG v NG Maps",
@@ -102,7 +114,21 @@ function TestMis:testRBENDmis() !-> ptc does rotation x, y, s not y, -x, s as ng
     },
   }
   
-  run_test(cfg)
+  require("test-tool").args_to_cfg(cfg) -- Need to check if we are doing a cmap test
+  if cfg.cmap then
+    cfg = cfg {
+      dtheta    = \s -> ((not s.cur_cfg.true_rbend and     s.cur_cfg.dodtheta) and {0, 1e-3,-0.1} or {0}),
+      dphi      = \s -> ((not s.cur_cfg.true_rbend and not s.cur_cfg.dodtheta) and {0,-1e-3, 0.1} or {0}),
+      dpsi      = \s -> ((not s.cur_cfg.true_rbend                           ) and {0, 1e-3,-0.1} or {0}), 
+      dodtheta  = {false, true},
+
+      alist = tblcat({"dodtheta"}, cfg.alist)
+    }
+    run_test(cfg)
+    MAD.warn("TestMis.testRBENDmis: Test limited to not combine dtheta and dphi, and not combining true_rbend along with rotational misalignment, as PTC does the rotations in a different order.")
+  else
+    run_test(cfg)
+  end
 end
 
 function TestMis:testQUADtrn()

--- a/tests/tests/test-ptc-maps/test-octu-maps.mad
+++ b/tests/tests/test-ptc-maps/test-octu-maps.mad
@@ -41,7 +41,7 @@ function TestOctupole:testOCT() -- Test the body (~2 min)
   }
   require("test-tool").args_to_cfg(cfg) -- Need to check if we are doing a cmap test
   if cfg.cmap then
-    cfg = cfg {
+    cfg = cfg "oct_c" {
       method = \s -> s.cur_cfg.model > 1 and {2, 4} or {2, 4, 6, 8},
     }
     run_test(cfg)

--- a/tests/tests/test-ptc-maps/test-octu-maps.mad
+++ b/tests/tests/test-ptc-maps/test-octu-maps.mad
@@ -39,7 +39,16 @@ function TestOctupole:testOCT() -- Test the body (~2 min)
       filename = "oct-body-comparision.png",
     }
   }
-  run_test(cfg)
+  require("test-tool").args_to_cfg(cfg) -- Need to check if we are doing a cmap test
+  if cfg.cmap then
+    cfg = cfg {
+      method = \s -> s.cur_cfg.model > 1 and {2, 4} or {2, 4, 6, 8},
+    }
+    run_test(cfg)
+    MAD.warn("TestOctupole.testOCT: model > 1 and method > 4 due to cmaps having shortcut to strex_kick from quad_kick_")
+  else
+    run_test(cfg)
+  end
 end
 
 -- This test needs testing w/ fringe and frngmax

--- a/tests/tests/test-ptc-maps/test-sext-maps.mad
+++ b/tests/tests/test-ptc-maps/test-sext-maps.mad
@@ -43,7 +43,7 @@ function TestSextupole:testSEXT() -- Test the body (~2 min)
   }
   require("test-tool").args_to_cfg(cfg) -- Need to check if we are doing a cmap test
   if cfg.cmap then
-    cfg = cfg {
+    cfg = cfg "sext_c" {
       method = \s -> s.cur_cfg.model > 1 and {2, 4} or {2, 4, 6, 8},
     }
     run_test(cfg)

--- a/tests/tests/test-ptc-maps/test-sext-maps.mad
+++ b/tests/tests/test-ptc-maps/test-sext-maps.mad
@@ -41,7 +41,16 @@ function TestSextupole:testSEXT() -- Test the body (~2 min)
       filename = "sext-body-comparision.png",
     }
   }
-  run_test(cfg)
+  require("test-tool").args_to_cfg(cfg) -- Need to check if we are doing a cmap test
+  if cfg.cmap then
+    cfg = cfg {
+      method = \s -> s.cur_cfg.model > 1 and {2, 4} or {2, 4, 6, 8},
+    }
+    run_test(cfg)
+    MAD.warn("TestSextupole.testSEXT: model > 1 and method > 4 skipped due to cmaps having shortcut to strex_kick from quad_kick_")
+  else
+    run_test(cfg)
+  end
 end
 
 -- This test needs testing w/ fringe and frngmax

--- a/tests/tests/test-ptc-maps/trackvsptc.mad
+++ b/tests/tests/test-ptc-maps/trackvsptc.mad
@@ -33,14 +33,17 @@ ref_file:close()
 local stop_and_restart = \cfg => cfg.stop, cfg.restart = true, true end
 
 local function chk_cfgfile (file_cfg, cur_cfg)
+  local keys_checked = {}
   for k, v in pairs(file_cfg) do
     if is_iterable(v) then chk_cfgfile(v, cur_cfg[k])
     elseif v ~= cur_cfg[k] then
-      if not (cur_cfg[k] or (is_number(v) and math.abs(v - cur_cfg[k]) < eps)) then
+      if not cur_cfg[k] or (is_number(v) and math.abs(v - cur_cfg[k]) > eps) then
         return false 
       end
     end
+    keys_checked[k] = true
   end
+  for k, v in pairs(cur_cfg) do if not keys_checked[k] then return false end end -- Check that all keys are checked
   return true
 end
 -- Run track and PTC from cur_cfg and create results --------------------------o
@@ -168,16 +171,18 @@ local function run_test(cfg)
   
   local num_cfg = 1
   for _, attr in ipairs(cfg.alist) do num_cfg = num_cfg * #cfg[attr] end
-  io.write(
-    "Running ", cfg.name, 
-    " (tol = ", tostring(cfg.tol), " eps, ", num_cfg, " configurations)\n"
-  )
-  io.write(
-    "setup =", cfg.dosave and " sv" or "", cfg.doplot and " plt" or "", 
-    cfg.doprnt > 0 and " prnt" or "", cfg.dodbg and " dbg" or "",
-    cfg.cmap and " cmap" or "", " coords", tostring(cfg.x0i),
-    " o", cfg.order, " icase", cfg.icase, " snm", cfg.snm, "\n"
-  )
+  if cfg.doprnt > 0 then
+    io.write(
+      "Running ", cfg.name, 
+      " (tol = ", tostring(cfg.tol), " eps, ", num_cfg, " configurations)\n"
+    )
+    io.write(
+      "setup =", cfg.dosave and " sv" or "", cfg.doplot and " plt" or "", 
+      cfg.doprnt > 0 and " prnt" or "", cfg.dodbg and " dbg" or "",
+      cfg.cmap and " cmap" or "", " coords", tostring(cfg.x0i),
+      " o", cfg.order, " icase", cfg.icase, " snm", cfg.snm, "\n"
+    )
+  end
   if cfg.doprnt > 1 then 
     io.write("cfgid\t")
     for i = 0, cfg.order do io.write("order ", i, "\t") end


### PR DESCRIPTION
- [Improve checking of cfg file and require verbosity of 1 for any printing](https://github.com/MethodicalAcceleratorDesign/MAD-NG/commit/6fe319165ebbf7192cbfc97590b6e101c2004181)
- [Add special cases + warning for cmap=true to ensure tests pass, but warnings are emitted](https://github.com/MethodicalAcceleratorDesign/MAD-NG/commit/dba727403a5d782b2b3b03eda8aee9f92823a993)