### PR TITLE
Fixing typo for scalar part of sinc, asinc, sinhc and asinhc

### DIFF
--- a/src/mad_tpsa_fun.c
+++ b/src/mad_tpsa_fun.c
@@ -468,7 +468,6 @@ FUN(sinc) (const T *a, T *c)
     };
     int s = 1; // o/2: even = 1, odd = -1
     num_t fact = 1;
-    ord_coef[0] = f0;
     for (ord_t o = 1; o <= to; o += 2, s = -s) {
       NUM v1 = 0, v2 = 0;
       FOR(i,7) {
@@ -484,6 +483,7 @@ FUN(sinc) (const T *a, T *c)
       };
       FOR(i,7) odd_coef[i] += stp_coef[i];
     }
+    ord_coef[0] = f0;
   } else { // sinc(x), |x| <= 1e-12
     ord_coef[0] = 1;
     ord_coef[1] = 0;
@@ -668,7 +668,6 @@ FUN(sinhc) (const T *a, T *c)
       3, 30, 840, 45360, 3991680, 518918400, 93405312000
     };
     num_t fact = 1;
-    ord_coef[0] = f0;
     for (ord_t o = 1; o <= to; o += 2) {
       NUM v1 = 0, v2 = 0;
       FOR(i,7) {
@@ -684,6 +683,7 @@ FUN(sinhc) (const T *a, T *c)
       };
       FOR(i,7) odd_coef[i] += stp_coef[i];
     }
+    ord_coef[0] = f0;
   } else { // sinhc(x), |x| <= 1e-12
     ord_coef[0] = 1;
     ord_coef[1] = 0;

--- a/src/mad_tpsa_fun.c
+++ b/src/mad_tpsa_fun.c
@@ -934,7 +934,7 @@ FUN(asinc) (const T *a, T *c)
   NUM ord_coef[to+1];
 
   if (fabs(a0) > 1e-12) { // asinc(x), 1e-12 < |x| <= 0.58
-    ord_coef[0] = f0; FOR(i,1,to+1) ord_coef[i] = 0;
+    FOR(i,1,to+1) ord_coef[i] = 0;
 
     enum { ord = 60 }; // specify according to the expected accuracy
     static num_t scl_coef[ord+1] = {0};
@@ -955,6 +955,7 @@ FUN(asinc) (const T *a, T *c)
         a0pi *= a0;
       }
     }
+    ord_coef[0] = f0;
   } else { // asinc(x), |x| <= 1e-12
     ord_coef[0] = 1;
     ord_coef[1] = 0;
@@ -1186,7 +1187,7 @@ FUN(asinhc) (const T *a, T *c)
   NUM ord_coef[to+1];
 
   if (fabs(a0) > 1e-12) { // asinhc(x), 1e-12 < |x| <= 0.62
-    ord_coef[0] = f0; FOR(i,1,to+1) ord_coef[i] = 0;
+    FOR(i,1,to+1) ord_coef[i] = 0;
 
     enum { ord = 80 }; // specify according to the expected accuracy
     static num_t scl_coef[ord+1] = {0};
@@ -1207,6 +1208,7 @@ FUN(asinhc) (const T *a, T *c)
         a0pi *= a0;
       }
     }
+    ord_coef[0] = f0;
   } else { // asinhc(x), |x| <= 1e-12
     ord_coef[0] = 1;
     ord_coef[1] = 0;

--- a/tests/utests/tpsa_fun.mad
+++ b/tests/utests/tpsa_fun.mad
@@ -23,7 +23,7 @@
 
 local vector, tpsa, ctpsa, gtpsad, monomial                      in MAD
 local eps, abs, pi                                               in MAD.constant
-local abs, fact, ceil                                                 in MAD.gmath
+local abs, fact, ceil                                            in MAD.gmath
 local ident                                                      in MAD.gfunc
 local assertTrue, assertEquals, assertAlmostEquals               in MAD.utest
 local is_number                                                  in MAD.typeid

--- a/tests/utests/tpsa_fun.mad
+++ b/tests/utests/tpsa_fun.mad
@@ -211,6 +211,9 @@ TestTPSAFun.testSinhc3D  = \ -> checkFun3D('sinhc'  , DEBUG)
 TestTPSAFun.testAsinc3D  = \ -> checkFun3D('asinc'  , DEBUG)
 TestTPSAFun.testAsinhc3D = \ -> checkFun3D('asinhc' , DEBUG)
 
+
+
+
 -- performance tests ----------------------------------------------------------o
 
 Test_TPSAFun = {}


### PR DESCRIPTION
I am just moving the initialization of ord_coef[0] to the bottom (otherwise it will be overwritten during the loop)