### PR TITLE
Quick fix for pymad pipe

### DIFF
--- a/src/madl_pymad.mad
+++ b/src/madl_pymad.mad
@@ -346,7 +346,7 @@ local function __ini (self, pyFd)
 end
 
 local function __fin (self)
-  self:send(1)
+  self:send("<closing pipe>")
   _C.fclose(self._toPy)
   self._run = false
   return self

--- a/src/madl_pymad.mad
+++ b/src/madl_pymad.mad
@@ -346,6 +346,7 @@ local function __ini (self, pyFd)
 end
 
 local function __fin (self)
+  self:send(1)
   _C.fclose(self._toPy)
   self._run = false
   return self


### PR DESCRIPTION
Add a send from pymad, so that python knows the pipe is empty and can also close the pipe on it's side.